### PR TITLE
Add exclusion rules for sdist and wheel build targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ r-snapshot = "pytest_r_snapshot.plugin"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["/docs", "/AGENTS.md", "/mkdocs.yml", "/uv.lock"]
+
+[tool.hatch.build.targets.wheel]
+exclude = ["/docs", "/AGENTS.md", "/mkdocs.yml", "/uv.lock"]
+
 [dependency-groups]
 dev = [
     "isort>=7.0.0",


### PR DESCRIPTION
To make the built packages more compact.