### PR TITLE
Add context for TDD in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![License](https://img.shields.io/pypi/l/pytest-r-snapshot)
 
 A pytest plugin for snapshot testing against reference outputs produced by R code.
+Particularly useful for test-driven development (TDD) when porting R packages to Python.
 
 It is designed for a portable workflow:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 ![License](https://img.shields.io/pypi/l/pytest-r-snapshot)
 
 A pytest plugin for snapshot testing against reference outputs produced by R code.
+Particularly useful for test-driven development (TDD) when porting R packages to Python.
 
 It is designed for a portable workflow:
 


### PR DESCRIPTION
This PR updates readme to further clarify the intended use case for the pytest plugin: for test-driven development (TDD) when porting R packages to Python.