### PR TITLE
Add timeout test for subprocess R runner

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
-from pytest_r_snapshot.errors import RscriptNotFoundError
+from pytest_r_snapshot.errors import RExecutionError, RscriptNotFoundError
 from pytest_r_snapshot.runner import SubprocessRRunner
+
+
+def _make_sleeping_rscript(tmp_path: Path) -> Path:
+    rscript_path = tmp_path / "Rscript"
+    rscript_path.write_text("#!/bin/sh\n/bin/sleep 5\n", encoding="utf-8")
+    rscript_path.chmod(rscript_path.stat().st_mode | 0o111)
+    return rscript_path
 
 
 def test_runner_missing_rscript_gives_helpful_message(tmp_path: Path) -> None:
@@ -15,3 +23,11 @@ def test_runner_missing_rscript_gives_helpful_message(tmp_path: Path) -> None:
     message = str(excinfo.value)
     assert "Rscript executable not found" in message
     assert "--r-snapshot-rscript" in message
+
+
+@pytest.mark.skipif(os.name == "nt", reason="relies on POSIX executable scripts")
+def test_runner_timeout_raises_execution_error(tmp_path: Path) -> None:
+    rscript = _make_sleeping_rscript(tmp_path)
+    runner = SubprocessRRunner(rscript=str(rscript), cwd=tmp_path, timeout=0.5)
+    with pytest.raises(RExecutionError, match="timed out"):
+        runner.run("Sys.sleep(5)")


### PR DESCRIPTION
This PR adds a POSIX-only timeout test that runs a sleeping `Rscript` shim, to make sure the timeout path raises `RExecutionError` without requiring R installed.