### PR TITLE
Cleanup mkdocs mentions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Design rule: keep `RSnapshot` as an orchestrator; parsing stays in `chunks`, sub
 - Lint/type-check (recommended):
   - `.venv/bin/ruff check`
   - `.venv/bin/mypy .`
-- Build docs: `.venv/bin/mkdocs build`
+- Build docs: `.venv/bin/zensical build`
 
 Note: in sandboxed environments, `uv run ...` may fail if `uv` cannot access its global cache; prefer `.venv/bin/...` or set `UV_CACHE_DIR` to a repo-local directory.
 
@@ -54,4 +54,4 @@ Note: in sandboxed environments, `uv run ...` may fail if `uv` cannot access its
 ## Docs hygiene
 
 - Update `README.md` and `docs/` together when user-facing behavior changes.
-- Keep mkdocs nav in `mkdocs.yml` in sync with `docs/`.
+- Keep zensical nav in `zensical.toml` in sync with `docs/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Documentation
 
-- Added README and mkdocs articles (setup, usage, configuration, troubleshooting, design, migration).
+- Added README and articles (setup, usage, configuration, troubleshooting, design, migration).
 
 ### Testing
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,7 @@
 
 ### Documentation
 
-- Added README and mkdocs articles (setup, usage, configuration, troubleshooting, design, migration).
+- Added README and articles (setup, usage, configuration, troubleshooting, design, migration).
 
 ### Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["/docs", "/AGENTS.md", "/mkdocs.yml", "/uv.lock"]
+exclude = ["/docs", "/AGENTS.md", "/zensical.toml", "/uv.lock"]
 
 [tool.hatch.build.targets.wheel]
-exclude = ["/docs", "/AGENTS.md", "/mkdocs.yml", "/uv.lock"]
+exclude = ["/docs", "/AGENTS.md", "/zensical.toml", "/uv.lock"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
This PR cleans up outdated mentions of `mkdocs` and replaces them with `zensical`.