### PR TITLE
Fix CSS selector syntax for nested navigation icon

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -65,7 +65,7 @@ body {
     font-weight: 600;
 }
 
-.md-nav__item--nested .md-nav__icon:after {
+.md-nav__item--nested .md-nav__icon::after {
     height: 150%;
 }
 


### PR DESCRIPTION
Use modern `::` syntax.