### PR TITLE
Explain default snapshot storage paths + improve documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
-Guidelines for AI coding agents working on `pytest-r-snapshot`.
+Guidelines for AI coding agents working on pytest-r-snapshot.
 
 ## Project overview
 
-- `pytest-r-snapshot` is a pytest plugin that snapshot-tests **Python outputs** against **reference outputs recorded from labelled R code chunks** embedded in Python test files.
+- pytest-r-snapshot is a pytest plugin that snapshot-tests **Python outputs** against **reference outputs recorded from labelled R code chunks** embedded in Python test files.
 - Default workflow is **portable CI**:
   - Developers run `pytest --r-snapshot=record` locally (requires R) and commit snapshot files.
   - CI runs in default `replay` mode (no R required).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### New features
 
-- Initial release of the `pytest-r-snapshot` pytest plugin for snapshot testing against R code outputs.
+- Initial release of the pytest-r-snapshot pytest plugin for snapshot testing against R code outputs.
 - Extract labelled R fenced chunks from Python source (commented chunks and raw chunks in docstrings/multiline strings).
 - Snapshot modes: `replay` (default), `record`, and `auto`.
 - Default snapshot layout: `__r_snapshots__/<test_file_stem>/<name><ext>` with configurable root via `--r-snapshot-dir` / `r_snapshot_dir`.

--- a/docs/articles/design.md
+++ b/docs/articles/design.md
@@ -1,6 +1,6 @@
 # Design
 
-`pytest-r-snapshot` is intentionally small and modular. The public API is the `r_snapshot` fixture (an `RSnapshot` instance) and a few helpers; everything else is internal plumbing to keep parsing, subprocess execution, and snapshot I/O isolated and testable.
+pytest-r-snapshot is intentionally built small and modular. The public API is the `r_snapshot` fixture (an `RSnapshot` instance) and a few helpers; everything else is internal plumbing to keep parsing, subprocess execution, and snapshot I/O isolated and testable.
 
 ## High-level flow
 

--- a/docs/articles/migration.md
+++ b/docs/articles/migration.md
@@ -1,6 +1,6 @@
 # Migration
 
-This guide outlines how to migrate from an ad hoc "run R chunks and save outputs" approach to `pytest-r-snapshot`.
+This guide outlines how to migrate from an ad hoc "run R chunks and save outputs" approach to pytest-r-snapshot.
 
 ## Keep your existing R chunks
 

--- a/docs/articles/setup.md
+++ b/docs/articles/setup.md
@@ -1,12 +1,12 @@
 # Setup
 
-This guide shows how to set up a project to use `pytest-r-snapshot`,
+This guide shows how to set up a project to use pytest-r-snapshot,
 including a recommended CI workflow that does **not** require R.
 
 ## Requirements
 
 - Python >= 3.10
-- `pytest` (installed automatically as a dependency)
+- pytest (installed automatically as a dependency)
 - **R (optional)**: Required for recording snapshots (`--r-snapshot=record` or `--r-snapshot=auto` when a snapshot is missing). Not required for replaying snapshots (the default mode)
 
 ## Install
@@ -54,7 +54,7 @@ If `r_snapshot_dir` is not set, snapshots are written next to the test file:
 
 ## Recording workflow
 
-1. Write tests that embed labelled R chunks (see `docs/articles/usage.md`).
+1. Write tests that embed labelled R chunks (see [Usage](usage.md)).
 2. Record snapshots locally:
     ```bash
     pytest --r-snapshot=record

--- a/docs/articles/usage.md
+++ b/docs/articles/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-`pytest-r-snapshot` records reference outputs from **labelled R code chunks** embedded in your Python test files, then compares your Python outputs to those recorded snapshots.
+pytest-r-snapshot records reference outputs from **labelled R code chunks** embedded in your Python test files, then compares your Python outputs to those recorded snapshots.
 
 ## Basic fixture usage
 
@@ -23,7 +23,7 @@ Record snapshots locally:
 pytest --r-snapshot=record
 ```
 
-By default, CI can run `pytest` in replay mode without R.
+By default, CI can run pytest in replay mode without R.
 
 ## Embedding R chunks
 
@@ -67,11 +67,21 @@ The plugin dedents the chunk body to remove Python indentation while keeping rel
 
 By default, for `tests/test_example.py`, snapshots are stored under:
 
-`tests/__r_snapshots__/test_example/<name><ext>`
+```
+tests/__r_snapshots__/test_example/<name><ext>
+```
 
-You can override the snapshot root directory with `--r-snapshot-dir` / `r_snapshot_dir`. In that case snapshots are stored under:
+Here, `test_example` is the `test_file_stem` (the pytest test file name without `.py`), and `name` is the R code chunk label. For example, a chunk labelled `summary` will use:
 
-`<r_snapshot_dir>/test_example/<name><ext>`
+```
+tests/__r_snapshots__/test_example/summary.txt
+```
+
+You can override the snapshot root directory with `--r-snapshot-dir` or `r_snapshot_dir`. In that case, snapshots are stored under:
+
+```
+<r_snapshot_dir>/<test_file_stem>/<name><ext>
+```
 
 The default file extension is `.txt`. You can change it per assertion:
 
@@ -90,7 +100,7 @@ Both `"rtf"` and `".rtf"` are accepted.
 Examples:
 
 ```bash
-pytest                  # replay
+pytest
 pytest --r-snapshot=auto
 pytest --r-snapshot=record
 ```
@@ -105,7 +115,7 @@ These options matter when the plugin needs to run R (`record` mode, or `auto` wi
 - `--r-snapshot-timeout=SECONDS` / `r_snapshot_timeout`: per-chunk timeout
 - `--r-snapshot-encoding=ENC` / `r_snapshot_encoding`: snapshot file encoding
 
-See `docs/articles/configuration.md` for the full reference and precedence rules.
+See [Configuration](configuration.md) for the full reference and precedence rules.
 
 ## Markers (optional)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,7 @@
 
 ### New features
 
-- Initial release of the `pytest-r-snapshot` pytest plugin for snapshot testing against R code outputs.
+- Initial release of the pytest-r-snapshot pytest plugin for snapshot testing against R code outputs.
 - Extract labelled R fenced chunks from Python source (commented chunks and raw chunks in docstrings/multiline strings).
 - Snapshot modes: `replay` (default), `record`, and `auto`.
 - Default snapshot layout: `__r_snapshots__/<test_file_stem>/<name><ext>` with configurable root via `--r-snapshot-dir` / `r_snapshot_dir`.


### PR DESCRIPTION
This PR:

- Explain default snapshot storage paths.
- Update links between pages.
- Use regular font instead of code font for package names.